### PR TITLE
Update to vertx 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     </scm>
 
     <properties>
-        <vertx.version>3.8.0</vertx.version>
+        <vertx.version>3.8.1</vertx.version>
         <jackson.version>2.9.9</jackson.version>
         <rxjava.version>2.2.11</rxjava.version>
         <reactive-streams.version>1.0.2</reactive-streams.version>

--- a/vertx-axle-clients/vertx-axle-generator/src/main/java/io/vertx/lang/axle/AbstractAxleGenerator.java
+++ b/vertx-axle-clients/vertx-axle-generator/src/main/java/io/vertx/lang/axle/AbstractAxleGenerator.java
@@ -609,8 +609,10 @@ public abstract class AbstractAxleGenerator extends Generator<ClassModel> {
             writer.println("   */");
         }
         writer.print(model.isConcrete() ? "  public static final" : "");
-        writer.println(" " + constant.getType().getSimpleName() + " " + constant.getName() + " = "
-                + genConvReturn(constant.getType(), null, model.getType().getName() + "." + constant.getName()) + ";");
+        writer.format(" %s %s = %s;%n",
+                genTypeName(constant.getType()),
+                constant.getName(),
+                genConvReturn(constant.getType(), null, model.getType().getName() + "." + constant.getName()));
     }
 
     protected void startMethodTemplate(boolean isPrivate, String methodName, MethodInfo method, String deprecated,

--- a/vertx-axle-clients/vertx-axle-generator/src/test/java/io/vertx/lang/axle/test/ReadStreamAdapterBackPressureTest.java
+++ b/vertx-axle-clients/vertx-axle-generator/src/test/java/io/vertx/lang/axle/test/ReadStreamAdapterBackPressureTest.java
@@ -97,6 +97,8 @@ public abstract class ReadStreamAdapterBackPressureTest<O> extends ReadStreamAda
         subscribe(observable, subscriber);
         if (err == null) {
             stream.end();
+            subscriber.assertEmpty();
+            subscriber.request(1);
             subscriber.assertCompleted();
         } else {
             stream.fail(err);
@@ -134,7 +136,9 @@ public abstract class ReadStreamAdapterBackPressureTest<O> extends ReadStreamAda
         for (int i = 0; i < count; i++) {
             subscriber.assertItem(Buffer.buffer("" + i));
         }
-        subscriber.assertCompleted().assertEmpty();
+        subscriber.assertEmpty();
+        subscriber.request(1);
+        subscriber.assertCompleted();
     }
 
     @Test
@@ -159,7 +163,7 @@ public abstract class ReadStreamAdapterBackPressureTest<O> extends ReadStreamAda
         } else {
             stream.fail(err);
         }
-        subscriber.request(2);
+        subscriber.request(3);
         if (err == null) {
             subscriber.assertItems(buffer("0"), buffer("1"));
             subscriber.assertCompleted();
@@ -190,7 +194,7 @@ public abstract class ReadStreamAdapterBackPressureTest<O> extends ReadStreamAda
         } else {
             stream.fail(err);
         }
-        subscriber.request(2);
+        subscriber.request(3);
         if (err == null) {
             subscriber.assertItems(buffer("0"), buffer("1"));
             subscriber.assertCompleted();
@@ -252,7 +256,9 @@ public abstract class ReadStreamAdapterBackPressureTest<O> extends ReadStreamAda
         for (int i = 0; i < count; i++) {
             subscriber.assertItem(Buffer.buffer("" + i));
         }
-        subscriber.assertCompleted().assertEmpty();
+        subscriber.assertEmpty();
+        subscriber.request(1);
+        subscriber.assertCompleted();
     }
 
     @Test
@@ -276,7 +282,9 @@ public abstract class ReadStreamAdapterBackPressureTest<O> extends ReadStreamAda
         stream.emit(buffer("0"));
         stream.end();
         subscriber.request(1);
-        subscriber.assertItem(buffer("0")).assertCompleted().assertEmpty();
+        subscriber.assertItem(buffer("0"));
+        subscriber.request(1);
+        subscriber.assertCompleted().assertEmpty();
     }
 
     @Test
@@ -363,7 +371,9 @@ public abstract class ReadStreamAdapterBackPressureTest<O> extends ReadStreamAda
         }
         subscriber.assertEmpty();
         stream.end();
-        subscriber.assertCompleted().assertEmpty();
+        subscriber.assertEmpty();
+        subscriber.request(1);
+        subscriber.assertCompleted();
     }
 
     @Test
@@ -377,6 +387,8 @@ public abstract class ReadStreamAdapterBackPressureTest<O> extends ReadStreamAda
         stream.emit(buffer("foo"));
         stream.end();
         subscriber.assertItem(buffer("foo"));
+        subscriber.assertEmpty();
+        subscriber.request(1);
         subscriber.assertCompleted();
     }
 


### PR DESCRIPTION
This PR:

1. Updates the Vert.x version to 3.8.1
2. Contains a fix for #63 - based on the fix made in Vert.x RX
3. Contains a fix for #39 updating the read stream tests as `FakeStream` has changed