### PR TITLE
Remove the dependency on log4j version 1

### DIFF
--- a/vertx-axle-clients/vertx-axle-core/pom.xml
+++ b/vertx-axle-clients/vertx-axle-core/pom.xml
@@ -108,7 +108,7 @@
                         </goals>
                         <configuration>
                             <includes>io/vertx/**/*.java</includes>
-                            <excludes>**/impl/**/*.java</excludes>
+                            <excludes>**/impl/**/*.java,io/vertx/core/logging/Log4jLogDelegate.java</excludes>
                             <outputDirectory>${gen.output}</outputDirectory>
                         </configuration>
                     </execution>
@@ -166,11 +166,6 @@
 
                 <!-- Log dependencies required by Vert.x -->
                 <dependencies>
-                    <dependency>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                        <version>1.2.17</version>
-                    </dependency>
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>

--- a/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
@@ -95,7 +95,7 @@
                         </goals>
                         <configuration>
                             <includes>io/vertx/**/*.java</includes>
-                            <excludes>**/impl/**/*.java</excludes>
+                            <excludes>**/impl/**/*.java,io/vertx/core/logging/Log4jLogDelegate.java</excludes>
                             <outputDirectory>${gen.output}</outputDirectory>
                         </configuration>
                     </execution>
@@ -153,11 +153,6 @@
 
                 <!-- Log dependencies required by Vert.x -->
                 <dependencies>
-                    <dependency>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                        <version>1.2.17</version>
-                    </dependency>
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>


### PR DESCRIPTION
The reason for this removal is the following:

A security vulnerability, CVE-2019-17571 has been identified against Log4j 1. Log4j includes a SocketServer that accepts serialized log events and deserializes them without verifying whether the objects are allowed or not. This can provide an attack vector that can be exploited. Since Log4j 1 is no longer maintained, this issue will not be fixed.

log4j 1 was only included for the Log facade. As this log facade is not involved during the generation and is not shipped with the generated API, this removal is harmless.