### PR TITLE
Implement a Mutiny version of AbstractVerticle

### DIFF
--- a/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/vertx-mutiny-clients/vertx-mutiny-core/src/main/java/io/smallrye/mutiny/vertx/core/AbstractVerticle.java
+++ b/vertx-mutiny-clients/vertx-mutiny-core/src/main/java/io/smallrye/mutiny/vertx/core/AbstractVerticle.java
@@ -1,0 +1,98 @@
+package io.smallrye.mutiny.vertx.core;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Context;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+public class AbstractVerticle extends io.vertx.core.AbstractVerticle {
+
+    protected io.vertx.mutiny.core.Vertx vertx;
+
+    /**
+     * Initialise the verticle.
+     * This is called by Vert.x when the verticle instance is deployed. Don't call it yourself.
+     *
+     * @param vertx the deploying Vert.x instance
+     * @param context the context of the verticle
+     */
+    @Override
+    public void init(Vertx vertx, Context context) {
+        super.init(vertx, context);
+        this.vertx = new io.vertx.mutiny.core.Vertx(vertx);
+    }
+
+    /**
+     * Start the verticle.
+     * This is called by Vert.x when the verticle instance is deployed. Don't call it yourself.
+     * <p>
+     * If your verticle does things in its startup which take some time then you can override this method
+     * and call the {@code startPromise} some time later when start up is complete.
+     *
+     * <strong>NOTE:</strong> Using {@link #asyncStart()} is recommended.
+     *
+     * @param startPromise a promise which should be called when verticle start-up is complete.
+     * @throws Exception
+     */
+    @Override
+    public void start(Promise<Void> startPromise) throws Exception {
+        Uni<Void> uni = asyncStart();
+        if (uni != null) {
+            uni.subscribe().with(x -> {
+                startPromise.complete(null);
+            }, startPromise::fail);
+        } else {
+            super.start(startPromise);
+        }
+    }
+
+    /**
+     * Stop the verticle.
+     * <p>
+     * This is called by Vert.x when the verticle instance is un-deployed. Don't call it yourself.
+     * If your verticle does things in its shut-down which take some time then you can override this method
+     * and call the {@code stopPromise} some time later when clean-up is complete.
+     *
+     * <strong>NOTE:</strong> Using {@link #asyncStop()} is recommended.
+     *
+     * @param stopPromise a promise which should be called when verticle clean-up is complete.
+     * @throws Exception
+     */
+    @Override
+    public void stop(Promise<Void> stopPromise) throws Exception {
+        Uni<Void> uni = asyncStop();
+        if (uni != null) {
+            uni.subscribe().with(x -> stopPromise.complete(), stopPromise::fail);
+        } else {
+            super.stop(stopPromise);
+        }
+    }
+
+    /**
+     * Start the verticle.
+     * This is called by Vert.x when the verticle instance is deployed. Don't call it yourself.
+     * <p>
+     * If your verticle does things in its startup which take some time then you can override this method
+     * and returns a {@link Uni} completed with the start up is complete. Propagating a failure fails the deployment
+     * of the verticle
+     *
+     * @return a {@link Uni} completed when the start up completes, or failed if the verticle cannot be started.
+     */
+    public Uni<Void> asyncStart() {
+        return null;
+    }
+
+    /**
+     * Stop the verticle.
+     * <p>
+     * This is called by Vert.x when the verticle instance is un-deployed. Don't call it yourself.
+     *
+     * If your verticle does things in its shut-down which take some time then you can override this method
+     * and returns an {@link Uni} completed when the clean-up is complete.
+     *
+     * @return a {@link Uni} completed when the clean-up completes, or failed if the verticle cannot be stopped gracefully.
+     */
+    public Uni<Void> asyncStop() {
+        return null;
+    }
+}

--- a/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/AbstractVerticleTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/AbstractVerticleTest.java
@@ -1,0 +1,68 @@
+package io.smallrye.mutiny.vertx.core.verticle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletionException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.mutiny.core.Vertx;
+
+public class AbstractVerticleTest {
+
+    private Vertx vertx;
+
+    @Before
+    public void setup() {
+        vertx = Vertx.vertx();
+    }
+
+    @After
+    public void tearDown() {
+        vertx.closeAndAwait();
+    }
+
+    @Test
+    public void testSuccessfulSynchronousDeployment() {
+        String deploymentId = vertx.deployVerticle(SyncVerticle.class.getName()).await().indefinitely();
+        assertThat(deploymentId).isNotNull().isNotBlank();
+        assertThat(SyncVerticle.DEPLOYED).isTrue();
+        vertx.undeploy(deploymentId).await().indefinitely();
+        assertThat(SyncVerticle.DEPLOYED).isFalse();
+    }
+
+    @Test
+    public void testSuccessfulAsynchronousDeployment() {
+        String deploymentId = vertx.deployVerticle(AsyncVerticle.class.getName()).await().indefinitely();
+        assertThat(deploymentId).isNotNull().isNotBlank();
+        assertThat(AsyncVerticle.DEPLOYED).isTrue();
+        vertx.undeploy(deploymentId).await().indefinitely();
+        assertThat(AsyncVerticle.DEPLOYED).isFalse();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testVerticleFailingSynchronouslyOnStart() {
+        vertx.deployVerticle(VerticleFailingSynchronously.class.getName()).await().indefinitely();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testVerticleFailingSynchronouslyOnStop() {
+        String deploymentId = vertx.deployVerticle(VerticleFailingSynchronouslyOnStop.class.getName()).await().indefinitely();
+        vertx.undeploy(deploymentId).await().indefinitely();
+    }
+
+    @Test(expected = CompletionException.class)
+    public void testVerticleFailingAsynchronouslyOnStart() {
+        vertx.deployVerticle(VerticleFailingAsynchronously.class.getName()).await().indefinitely();
+    }
+
+    @Test(expected = CompletionException.class)
+    public void testVerticleFailingAsynchronouslyOnStop() {
+        String deploymentId = vertx.deployVerticle(VerticleFailingAsynchronouslyOnStop.class.getName())
+                .await().indefinitely();
+        vertx.undeploy(deploymentId).await().indefinitely();
+    }
+
+}

--- a/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/AsyncVerticle.java
+++ b/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/AsyncVerticle.java
@@ -1,0 +1,35 @@
+package io.smallrye.mutiny.vertx.core.verticle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.core.AbstractVerticle;
+import io.vertx.mutiny.core.Vertx;
+
+public class AsyncVerticle extends AbstractVerticle {
+
+    volatile static boolean DEPLOYED = false;
+
+    @Override
+    public Uni<Void> asyncStart() {
+        assertThat(vertx).isNotNull().isInstanceOf(Vertx.class);
+        return vertx.eventBus().consumer("foo")
+                .handler(m -> {
+                })
+                .completionHandler().onItem().invoke(x -> {
+                    DEPLOYED = true;
+                });
+    }
+
+    @Override
+    public Uni<Void> asyncStop() {
+        assertThat(vertx).isNotNull().isInstanceOf(Vertx.class);
+        return Uni.createFrom().completionStage(() -> CompletableFuture.supplyAsync(() -> null))
+                .onItem().apply(x -> {
+                    DEPLOYED = false;
+                    return null;
+                });
+    }
+}

--- a/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/SyncVerticle.java
+++ b/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/SyncVerticle.java
@@ -1,0 +1,23 @@
+package io.smallrye.mutiny.vertx.core.verticle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.smallrye.mutiny.vertx.core.AbstractVerticle;
+import io.vertx.mutiny.core.Vertx;
+
+public class SyncVerticle extends AbstractVerticle {
+
+    volatile static boolean DEPLOYED = false;
+
+    @Override
+    public void start() {
+        assertThat(vertx).isNotNull().isInstanceOf(Vertx.class);
+        DEPLOYED = true;
+    }
+
+    @Override
+    public void stop() {
+        assertThat(vertx).isNotNull().isInstanceOf(Vertx.class);
+        DEPLOYED = false;
+    }
+}

--- a/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/VerticleFailingAsynchronously.java
+++ b/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/VerticleFailingAsynchronously.java
@@ -1,0 +1,16 @@
+package io.smallrye.mutiny.vertx.core.verticle;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.core.AbstractVerticle;
+
+public class VerticleFailingAsynchronously extends AbstractVerticle {
+
+    @Override
+    public Uni<Void> asyncStart() {
+        return Uni.createFrom().completionStage(() -> CompletableFuture.supplyAsync(() -> {
+            throw new NullPointerException("boom");
+        }));
+    }
+}

--- a/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/VerticleFailingAsynchronouslyOnStop.java
+++ b/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/VerticleFailingAsynchronouslyOnStop.java
@@ -1,0 +1,16 @@
+package io.smallrye.mutiny.vertx.core.verticle;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.core.AbstractVerticle;
+
+public class VerticleFailingAsynchronouslyOnStop extends AbstractVerticle {
+
+    @Override
+    public Uni<Void> asyncStop() {
+        return Uni.createFrom().completionStage(() -> CompletableFuture.supplyAsync(() -> {
+            throw new NullPointerException("boom");
+        }));
+    }
+}

--- a/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/VerticleFailingSynchronously.java
+++ b/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/VerticleFailingSynchronously.java
@@ -1,0 +1,12 @@
+package io.smallrye.mutiny.vertx.core.verticle;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.core.AbstractVerticle;
+
+public class VerticleFailingSynchronously extends AbstractVerticle {
+
+    @Override
+    public Uni<Void> asyncStart() {
+        throw new NullPointerException("boom");
+    }
+}

--- a/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/VerticleFailingSynchronouslyOnStop.java
+++ b/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/smallrye/mutiny/vertx/core/verticle/VerticleFailingSynchronouslyOnStop.java
@@ -1,0 +1,12 @@
+package io.smallrye.mutiny.vertx.core.verticle;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.vertx.core.AbstractVerticle;
+
+public class VerticleFailingSynchronouslyOnStop extends AbstractVerticle {
+
+    @Override
+    public Uni<Void> asyncStop() {
+        throw new NullPointerException("boom");
+    }
+}


### PR DESCRIPTION
Fix https://github.com/smallrye/smallrye-reactive-utils/issues/109.
Implement a Mutiny version of AbstractVerticle

It provides a version of AbstractVerticle allowing the user to return `Uni` instances for the start and stop callbacks (`asyncStart` and `asyncStop` methods).