### PR TITLE
Fix incorrect WebSocket test

### DIFF
--- a/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/vertx/mutiny/test/CoreTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-core/src/test/java/io/vertx/mutiny/test/CoreTest.java
@@ -90,7 +90,8 @@ public class CoreTest extends VertxTestBase {
             ws.toMulti()
                     .subscribe().with(msg -> {
                         serverReceived.incrementAndGet();
-                        ws.writeTextMessage("pong");
+                        ws.writeTextMessage("pong").subscribe().with(v -> {
+                        });
                     }, err -> {
                         assertEquals(1, serverReceived.get());
                         complete();
@@ -103,7 +104,10 @@ public class CoreTest extends VertxTestBase {
                 .onItem().call(ws -> ws.writeTextMessage("ping"))
                 .onItem().transformToMulti(WebSocket::toMulti)
                 .subscribe().with(
-                        msg -> clientReceived.incrementAndGet(), err -> complete(), this::fail);
+                        msg -> clientReceived.incrementAndGet(), err -> {
+                            assertEquals(1, clientReceived.get());
+                            complete();
+                        }, this::fail);
         await();
     }
 


### PR DESCRIPTION
The core API test for WebSocket is incorrect as it doesn't call subscribe when sending the pong message reply to the client.