### PR TITLE
Upgrade to Mutiny 0.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <properties>
         <vertx.version>4.0.2</vertx.version>
-        <mutiny.version>0.13.0</mutiny.version>
+        <mutiny.version>0.14.0</mutiny.version>
         <jackson.version>2.12.0</jackson.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <rxjava1.version>1.3.8</rxjava1.version>
         <reactor-core.version>3.4.3</reactor-core.version>
 
-        <testcontainers.version>1.15.1</testcontainers.version>
+        <testcontainers.version>1.15.2</testcontainers.version>
 
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <rxjava3.version>3.0.10</rxjava3.version>
         <rxjava2.version>2.2.21</rxjava2.version>
         <rxjava1.version>1.3.8</rxjava1.version>
-        <reactor-core.version>3.4.2</reactor-core.version>
+        <reactor-core.version>3.4.3</reactor-core.version>
 
         <testcontainers.version>1.15.1</testcontainers.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
 
         <rxjava3.version>3.0.10</rxjava3.version>
-        <rxjava2.version>2.2.20</rxjava2.version>
+        <rxjava2.version>2.2.21</rxjava2.version>
         <rxjava1.version>1.3.8</rxjava1.version>
         <reactor-core.version>3.4.2</reactor-core.version>
 

--- a/vertx-mutiny-clients/vertx-mutiny-runtime/src/main/java/io/smallrye/mutiny/vertx/AsyncResultUni.java
+++ b/vertx-mutiny-clients/vertx-mutiny-runtime/src/main/java/io/smallrye/mutiny/vertx/AsyncResultUni.java
@@ -21,7 +21,7 @@ public class AsyncResultUni<T> extends AbstractUni<T> implements Uni<T> {
     }
 
     @Override
-    protected void subscribing(UniSubscriber<? super T> downstream) {
+    public void subscribe(UniSubscriber<? super T> downstream) {
         AtomicBoolean terminated = new AtomicBoolean();
         downstream.onSubscribe(() -> terminated.set(true));
 


### PR DESCRIPTION
- Update to Mutiny 0.14.0
- Update to RX Java 2.2.21
- Update to Reactor Core 3.4.3
- Update test containers to 1.15.2