### PR TITLE
[2.x] Bump rxjava from 3.0.10 to 3.0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <jackson.version>2.12.0</jackson.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
 
-        <rxjava3.version>3.0.10</rxjava3.version>
+        <rxjava3.version>3.0.11</rxjava3.version>
         <rxjava2.version>2.2.21</rxjava2.version>
         <rxjava1.version>1.3.8</rxjava1.version>
         <reactor-core.version>3.4.3</reactor-core.version>


### PR DESCRIPTION
Backported from #258