### PR TITLE
[2.x] Backport Bump revapi-maven-plugin from 0.12.2 to 0.13.4

### DIFF
--- a/vertx-mutiny-clients/pom.xml
+++ b/vertx-mutiny-clients/pom.xml
@@ -144,7 +144,7 @@
                     <plugin>
                         <groupId>org.revapi</groupId>
                         <artifactId>revapi-maven-plugin</artifactId>
-                        <version>0.13.2</version>
+                        <version>0.13.4</version>
                         <dependencies>
                             <dependency>
                                 <groupId>org.revapi</groupId>


### PR DESCRIPTION
Backport #264 to 2.x.