### PR TITLE
[2.x] Backport Bump log4j-api from 2.13.3 to 2.14.1

### DIFF
--- a/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-core/pom.xml
@@ -168,7 +168,7 @@
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>
-                        <version>2.13.3</version>
+                        <version>2.14.1</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Backport #267 to 2.x.
