### PR TITLE
Remove dependency on Zookeeper and Scala in the RabbitMQ client.

### DIFF
--- a/vertx-mutiny-clients/vertx-mutiny-rabbitmq-client/pom.xml
+++ b/vertx-mutiny-clients/vertx-mutiny-rabbitmq-client/pom.xml
@@ -25,14 +25,6 @@
             <version>${vertx.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.scala-lang</groupId>
-                    <artifactId>scala-reflect</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
@@ -44,17 +36,6 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>smallrye-mutiny-vertx-core</artifactId>
             <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-reflect</artifactId>
-            <version>2.13.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>3.5.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fix https://github.com/smallrye/smallrye-reactive-utils/issues/293.