### PR TITLE
SqlClientHelper: fix transaction management

### DIFF
--- a/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySQLClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySQLClientTest.java
@@ -2,10 +2,7 @@ package io.vertx.mutiny.mysql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.testcontainers.containers.GenericContainer;
 
 import io.vertx.mutiny.core.Vertx;
@@ -19,8 +16,8 @@ public class MySQLClientTest {
     private static final String MYSQL_ROOT_PASSWORD = "my-secret-pw";
     private static final String MYSQL_DATABASE = "test";
 
-    @Rule
-    public GenericContainer<?> container = new GenericContainer<>("mysql:latest")
+    @ClassRule
+    public static GenericContainer<?> container = new GenericContainer<>("mysql:latest")
             .withExposedPorts(3306)
             .withEnv("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
             .withEnv("MYSQL_DATABASE", MYSQL_DATABASE);

--- a/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlInTransactionMultiTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlInTransactionMultiTest.java
@@ -1,8 +1,10 @@
 package io.vertx.mutiny.mysql;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.testcontainers.containers.GenericContainer;
 
 import io.vertx.mutiny.core.Vertx;
@@ -15,8 +17,8 @@ public class MySqlInTransactionMultiTest extends TransactionMultiTest {
     private static final String MYSQL_ROOT_PASSWORD = "my-secret-pw";
     private static final String MYSQL_DATABASE = "test";
 
-    @Rule
-    public GenericContainer<?> container = new GenericContainer<>("mysql:latest")
+    @ClassRule
+    public static GenericContainer<?> container = new GenericContainer<>("mysql:latest")
             .withExposedPorts(3306)
             .withEnv("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
             .withEnv("MYSQL_DATABASE", MYSQL_DATABASE);
@@ -43,5 +45,10 @@ public class MySqlInTransactionMultiTest extends TransactionMultiTest {
     public void tearDown() {
         pool.close();
         vertx.closeAndAwait();
+    }
+
+    @Override
+    protected void verifyDuplicateException(Exception e) {
+        assertThat(e).hasMessageContaining("Duplicate entry");
     }
 }

--- a/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlInTransactionUniTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlInTransactionUniTest.java
@@ -1,8 +1,10 @@
 package io.vertx.mutiny.mysql;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.testcontainers.containers.GenericContainer;
 
 import io.vertx.mutiny.core.Vertx;
@@ -15,8 +17,8 @@ public class MySqlInTransactionUniTest extends TransactionUniTest {
     private static final String MYSQL_ROOT_PASSWORD = "my-secret-pw";
     private static final String MYSQL_DATABASE = "test";
 
-    @Rule
-    public GenericContainer<?> container = new GenericContainer<>("mysql:latest")
+    @ClassRule
+    public static GenericContainer<?> container = new GenericContainer<>("mysql:latest")
             .withExposedPorts(3306)
             .withEnv("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
             .withEnv("MYSQL_DATABASE", MYSQL_DATABASE);
@@ -43,5 +45,10 @@ public class MySqlInTransactionUniTest extends TransactionUniTest {
     public void tearDown() {
         pool.close();
         vertx.closeAndAwait();
+    }
+
+    @Override
+    protected void verifyDuplicateException(Exception e) {
+        assertThat(e).hasMessageContaining("Duplicate entry");
     }
 }

--- a/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlUsingConnectionSafetyTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlUsingConnectionSafetyTest.java
@@ -2,7 +2,7 @@ package io.vertx.mutiny.mysql;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.testcontainers.containers.GenericContainer;
 
 import io.vertx.mutiny.core.Vertx;
@@ -15,8 +15,8 @@ public class MySqlUsingConnectionSafetyTest extends UsingConnectionSafetyTest {
     private static final String MYSQL_ROOT_PASSWORD = "my-secret-pw";
     private static final String MYSQL_DATABASE = "test";
 
-    @Rule
-    public GenericContainer<?> container = new GenericContainer<>("mysql:latest")
+    @ClassRule
+    public static GenericContainer<?> container = new GenericContainer<>("mysql:latest")
             .withExposedPorts(3306)
             .withEnv("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
             .withEnv("MYSQL_DATABASE", MYSQL_DATABASE);

--- a/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgInTransactionMultiTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgInTransactionMultiTest.java
@@ -1,6 +1,10 @@
 package io.vertx.mutiny.postgresql;
 
-import org.junit.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import io.vertx.mutiny.core.Vertx;
@@ -11,8 +15,8 @@ import io.vertx.sqlclient.PoolOptions;
 
 public class PgInTransactionMultiTest extends TransactionMultiTest {
 
-    @Rule
-    public PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:latest");
+    @ClassRule
+    public static PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:latest");
 
     private Vertx vertx;
 
@@ -36,5 +40,10 @@ public class PgInTransactionMultiTest extends TransactionMultiTest {
     public void tearDown() {
         pool.close();
         vertx.closeAndAwait();
+    }
+
+    @Override
+    protected void verifyDuplicateException(Exception e) {
+        assertThat(e).hasMessageContaining("duplicate key value violates unique constraint");
     }
 }

--- a/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgInTransactionMultiTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgInTransactionMultiTest.java
@@ -12,7 +12,7 @@ import io.vertx.sqlclient.PoolOptions;
 public class PgInTransactionMultiTest extends TransactionMultiTest {
 
     @Rule
-    public PostgreSQLContainer<?> container = new PostgreSQLContainer<>();
+    public PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:latest");
 
     private Vertx vertx;
 

--- a/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgInTransactionUniTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgInTransactionUniTest.java
@@ -14,7 +14,7 @@ import io.vertx.sqlclient.PoolOptions;
 public class PgInTransactionUniTest extends TransactionUniTest {
 
     @Rule
-    public PostgreSQLContainer<?> container = new PostgreSQLContainer<>();
+    public PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:latest");
 
     private Vertx vertx;
 

--- a/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgInTransactionUniTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgInTransactionUniTest.java
@@ -1,8 +1,10 @@
 package io.vertx.mutiny.postgresql;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import io.vertx.mutiny.core.Vertx;
@@ -13,8 +15,8 @@ import io.vertx.sqlclient.PoolOptions;
 
 public class PgInTransactionUniTest extends TransactionUniTest {
 
-    @Rule
-    public PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:latest");
+    @ClassRule
+    public static PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:latest");
 
     private Vertx vertx;
 
@@ -38,5 +40,10 @@ public class PgInTransactionUniTest extends TransactionUniTest {
     public void tearDown() {
         pool.close();
         vertx.closeAndAwait();
+    }
+
+    @Override
+    protected void verifyDuplicateException(Exception e) {
+        assertThat(e).hasMessageContaining("duplicate key value violates unique constraint");
     }
 }

--- a/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgUsingConnectionSafetyTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgUsingConnectionSafetyTest.java
@@ -14,7 +14,7 @@ import io.vertx.sqlclient.PoolOptions;
 public class PgUsingConnectionSafetyTest extends UsingConnectionSafetyTest {
 
     @Rule
-    public PostgreSQLContainer<?> container = new PostgreSQLContainer<>();
+    public PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:latest");
 
     private Vertx vertx;
     private int maxSize;

--- a/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgUsingConnectionSafetyTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PgUsingConnectionSafetyTest.java
@@ -2,7 +2,7 @@ package io.vertx.mutiny.postgresql;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import io.vertx.mutiny.core.Vertx;
@@ -13,8 +13,8 @@ import io.vertx.sqlclient.PoolOptions;
 
 public class PgUsingConnectionSafetyTest extends UsingConnectionSafetyTest {
 
-    @Rule
-    public PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:latest");
+    @ClassRule
+    public static PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:latest");
 
     private Vertx vertx;
     private int maxSize;

--- a/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PostGreSQLClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-pg-client/src/test/java/io/vertx/mutiny/postgresql/PostGreSQLClientTest.java
@@ -2,10 +2,7 @@ package io.vertx.mutiny.postgresql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import io.smallrye.mutiny.Uni;
@@ -20,8 +17,8 @@ import io.vertx.sqlclient.PoolOptions;
 
 public class PostGreSQLClientTest {
 
-    @Rule
-    public PostgreSQLContainer<?> container = new PostgreSQLContainer<>();
+    @ClassRule
+    public static PostgreSQLContainer<?> container = new PostgreSQLContainer<>();
 
     private Vertx vertx;
 

--- a/vertx-mutiny-clients/vertx-mutiny-sql-client/src/main/java/io/vertx/mutiny/sqlclient/SqlClientHelper.java
+++ b/vertx-mutiny-clients/vertx-mutiny-sql-client/src/main/java/io/vertx/mutiny/sqlclient/SqlClientHelper.java
@@ -25,7 +25,7 @@ public class SqlClientHelper {
             return conn.begin().onItem().transformToMulti(tx -> {
                 Multi<T> multi = Multi.createBy().concatenating().streams(
                         sourceSupplier.apply(conn),
-                        tx.commit().toMulti().onItem().transform(v -> null));
+                        tx.commit().onItem().transformToMulti(v -> Multi.createFrom().empty()));
                 return multi.onFailure().recoverWithMulti(err -> {
                     return err instanceof TransactionRollbackException ? Multi.createFrom().failure(err)
                             : rollbackMulti(tx, err);

--- a/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/SqlClientHelperTestBase.java
+++ b/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/SqlClientHelperTestBase.java
@@ -12,7 +12,7 @@ import io.smallrye.mutiny.Uni;
 
 public abstract class SqlClientHelperTestBase {
 
-    protected static final List<String> NAMES = Arrays.asList("John", "Paul", "Peter", "Andrew", "Peter", "Steven");
+    protected static final List<String> NAMES = Arrays.asList("John", "Paul", "Peter", "Andrew", "Steven");
 
     protected static final String UNIQUE_NAMES_SQL = "select distinct firstname from folks order by firstname asc";
 
@@ -22,7 +22,7 @@ public abstract class SqlClientHelperTestBase {
 
     public void initDb() {
         pool.query("drop table if exists folks").executeAndAwait();
-        pool.query("create table folks (firstname varchar(255) not null)").executeAndAwait();
+        pool.query("create table folks (firstname varchar(255) not null unique)").executeAndAwait();
         for (String name : NAMES) {
             pool.query(String.format(INSERT_FOLK_SQL, name)).executeAndAwait();
         }

--- a/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/TransactionMultiTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/TransactionMultiTest.java
@@ -15,8 +15,8 @@ public abstract class TransactionMultiTest extends SqlClientHelperTestBase {
 
     @Test
     public void inTransactionSuccess() throws Exception {
-        List<String> actual = inTransaction(null).collectItems().asList().await().indefinitely();
-        assertThat(actual).containsExactlyInAnyOrderElementsOf(namesWithExtraFolks());
+        List<String> actual = inTransaction(null).collect().asList().await().indefinitely();
+        assertThat(actual).isEqualTo(namesWithExtraFolks());
     }
 
     @Test
@@ -24,10 +24,10 @@ public abstract class TransactionMultiTest extends SqlClientHelperTestBase {
         Exception failure = new Exception();
         List<String> emitted = Collections.synchronizedList(new ArrayList<>());
         try {
-            inTransaction(failure).onItem().invoke(emitted::add).collectItems().asList().await().indefinitely();
+            inTransaction(failure).onItem().invoke(emitted::add).collect().asList().await().indefinitely();
         } catch (Exception e) {
             assertThat(e).isInstanceOf(CompletionException.class).getCause().isEqualTo(failure);
-            assertThat(emitted).containsExactlyInAnyOrderElementsOf(namesWithExtraFolks());
+            assertThat(emitted).isEqualTo(namesWithExtraFolks());
         }
         assertTableContainsInitDataOnly();
     }

--- a/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/TransactionMultiTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/TransactionMultiTest.java
@@ -13,18 +13,19 @@ import io.smallrye.mutiny.Multi;
 
 public abstract class TransactionMultiTest extends SqlClientHelperTestBase {
 
+    List<String> emitted = Collections.synchronizedList(new ArrayList<>());
+
     @Test
     public void inTransactionSuccess() throws Exception {
-        List<String> actual = inTransaction(null).collect().asList().await().indefinitely();
-        assertThat(actual).isEqualTo(namesWithExtraFolks());
+        inTransaction(false, null);
+        assertThat(emitted).isEqualTo(namesWithExtraFolks());
     }
 
     @Test
-    public void inTransactionFailure() throws Exception {
+    public void inTransactionUserFailure() throws Exception {
         Exception failure = new Exception();
-        List<String> emitted = Collections.synchronizedList(new ArrayList<>());
         try {
-            inTransaction(failure).onItem().invoke(emitted::add).collect().asList().await().indefinitely();
+            inTransaction(true, failure);
         } catch (Exception e) {
             assertThat(e).isInstanceOf(CompletionException.class).getCause().isEqualTo(failure);
             assertThat(emitted).isEqualTo(namesWithExtraFolks());
@@ -32,14 +33,30 @@ public abstract class TransactionMultiTest extends SqlClientHelperTestBase {
         assertTableContainsInitDataOnly();
     }
 
-    private Multi<String> inTransaction(Exception e) throws Exception {
-        return SqlClientHelper.inTransactionMulti(pool, transaction -> {
+    @Test
+    public void inTransactionDBFailure() throws Exception {
+        try {
+            inTransaction(true, null);
+        } catch (Exception e) {
+            verifyDuplicateException(e);
+            assertThat(emitted).isEqualTo(namesWithExtraFolks());
+        }
+        assertTableContainsInitDataOnly();
+    }
+
+    protected abstract void verifyDuplicateException(Exception e);
+
+    private void inTransaction(boolean fail, Exception e) throws Exception {
+        SqlClientHelper.inTransactionMulti(pool, transaction -> {
             Multi<String> upstream = insertExtraFolks(transaction)
                     .onItem().transformToMulti(v -> uniqueNames(transaction));
-            if (e == null) {
+            if (!fail) {
                 return upstream;
             }
-            return Multi.createBy().concatenating().streams(upstream, Multi.createFrom().failure(e));
-        });
+            if (e != null) {
+                return Multi.createBy().concatenating().streams(upstream, Multi.createFrom().failure(e));
+            }
+            return Multi.createBy().concatenating().streams(upstream, upstream);
+        }).onItem().invoke(emitted::add).collect().last().await().indefinitely();
     }
 }

--- a/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/TransactionUniTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/TransactionUniTest.java
@@ -28,21 +28,21 @@ public abstract class TransactionUniTest extends SqlClientHelperTestBase {
 
     @Test
     public void inTransactionSuccess() {
-        List<String> actual = inTransaction(null).await().indefinitely();
+        List<String> actual = inTransaction(false, null);
         assertThat(actual).isEqualTo(namesWithExtraFolks());
     }
 
     @Test
     public void withTransactionSuccess() {
-        List<String> actual = withTransaction(null).await().indefinitely();
+        List<String> actual = withTransaction(false, null);
         assertThat(actual).isEqualTo(namesWithExtraFolks());
     }
 
     @Test
-    public void inTransactionFailure() throws Exception {
+    public void inTransactionUserFailure() throws Exception {
         Exception failure = new Exception();
         try {
-            inTransaction(failure).await().indefinitely();
+            inTransaction(true, failure);
             fail("Exception expected");
         } catch (Exception e) {
             assertThat(e).isInstanceOf(CompletionException.class).getCause().isEqualTo(failure);
@@ -51,10 +51,21 @@ public abstract class TransactionUniTest extends SqlClientHelperTestBase {
     }
 
     @Test
-    public void withTransactionFailure() throws Exception {
+    public void inTransactionDBFailure() throws Exception {
+        try {
+            inTransaction(true, null);
+            fail("Exception expected");
+        } catch (Exception e) {
+            verifyDuplicateException(e);
+        }
+        assertTableContainsInitDataOnly();
+    }
+
+    @Test
+    public void withTransactionUserFailure() throws Exception {
         Exception failure = new Exception();
         try {
-            withTransaction(failure).await().indefinitely();
+            withTransaction(true, failure);
             fail("Exception expected");
         } catch (Exception e) {
             assertThat(e).isInstanceOf(CompletionException.class).getCause().isEqualTo(failure);
@@ -62,25 +73,44 @@ public abstract class TransactionUniTest extends SqlClientHelperTestBase {
         assertTableContainsInitDataOnly();
     }
 
-    private Uni<List<String>> inTransaction(Exception e) {
+    @Test
+    public void withTransactionDBFailure() throws Exception {
+        try {
+            withTransaction(true, null);
+            fail("Exception expected");
+        } catch (Exception e) {
+            verifyDuplicateException(e);
+        }
+        assertTableContainsInitDataOnly();
+    }
+
+    protected abstract void verifyDuplicateException(Exception e);
+
+    private List<String> inTransaction(boolean fail, Exception e) {
         return SqlClientHelper.inTransactionUni(pool, transaction -> {
             Uni<List<String>> upstream = insertExtraFolks(transaction)
                     .onItem().transformToUni(v -> uniqueNames(transaction).collect().asList());
-            if (e == null) {
+            if (!fail) {
                 return upstream;
             }
-            return upstream.onItem().transformToUni(v -> Uni.createFrom().failure(e));
-        });
+            if (e != null) {
+                return upstream.onItem().transformToUni(v -> Uni.createFrom().failure(e));
+            }
+            return upstream.replaceWith(upstream);
+        }).await().indefinitely();
     }
 
-    private Uni<List<String>> withTransaction(Exception e) {
+    private List<String> withTransaction(boolean fail, Exception e) {
         return pool.withTransaction(connection -> {
             Uni<List<String>> upstream = insertExtraFolks(connection)
                     .onItem().transformToUni(v -> uniqueNames(connection).collect().asList());
-            if (e == null) {
+            if (!fail) {
                 return upstream;
             }
-            return upstream.onItem().transformToUni(v -> Uni.createFrom().failure(e));
-        });
+            if (e != null) {
+                return upstream.onItem().transformToUni(v -> Uni.createFrom().failure(e));
+            }
+            return upstream.replaceWith(upstream);
+        }).await().indefinitely();
     }
 }

--- a/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/TransactionUniTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/TransactionUniTest.java
@@ -29,13 +29,13 @@ public abstract class TransactionUniTest extends SqlClientHelperTestBase {
     @Test
     public void inTransactionSuccess() {
         List<String> actual = inTransaction(null).await().indefinitely();
-        assertThat(actual).containsExactlyInAnyOrderElementsOf(namesWithExtraFolks());
+        assertThat(actual).isEqualTo(namesWithExtraFolks());
     }
 
     @Test
     public void withTransactionSuccess() {
         List<String> actual = withTransaction(null).await().indefinitely();
-        assertThat(actual).containsExactlyInAnyOrderElementsOf(namesWithExtraFolks());
+        assertThat(actual).isEqualTo(namesWithExtraFolks());
     }
 
     @Test
@@ -65,7 +65,7 @@ public abstract class TransactionUniTest extends SqlClientHelperTestBase {
     private Uni<List<String>> inTransaction(Exception e) {
         return SqlClientHelper.inTransactionUni(pool, transaction -> {
             Uni<List<String>> upstream = insertExtraFolks(transaction)
-                    .onItem().transformToUni(v -> uniqueNames(transaction).collectItems().asList());
+                    .onItem().transformToUni(v -> uniqueNames(transaction).collect().asList());
             if (e == null) {
                 return upstream;
             }
@@ -76,7 +76,7 @@ public abstract class TransactionUniTest extends SqlClientHelperTestBase {
     private Uni<List<String>> withTransaction(Exception e) {
         return pool.withTransaction(connection -> {
             Uni<List<String>> upstream = insertExtraFolks(connection)
-                    .onItem().transformToUni(v -> uniqueNames(connection).collectItems().asList());
+                    .onItem().transformToUni(v -> uniqueNames(connection).collect().asList());
             if (e == null) {
                 return upstream;
             }

--- a/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/UsingConnectionSafetyTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-sql-client/src/test/java/io/vertx/mutiny/sqlclient/UsingConnectionSafetyTest.java
@@ -17,7 +17,7 @@ public abstract class UsingConnectionSafetyTest {
     public void testUsingConnectionMulti() throws Exception {
         doTest(throwable -> SqlClientHelper.usingConnectionMulti(pool, conn -> {
             throw throwable;
-        }).collectItems().first());
+        }).collect().first());
     }
 
     @Test


### PR DESCRIPTION
Related to https://github.com/quarkusio/quarkus/issues/16430

When a problem occurs on the DB side (e.g. constraint violation), the SqlClientHelper implementation must convey the original error message to the user.

Also, in order to avoid a redundant call to the SqlClient#rollback, we can check if the failure is a TransactionRollbackException.