### PR TITLE
update to vertx 4.1.0.CR2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -43,7 +43,7 @@
     </scm>
 
     <properties>
-        <vertx.version>4.0.3</vertx.version>
+        <vertx.version>4.1.0.CR2</vertx.version>
         <mutiny.version>0.17.0</mutiny.version>
         <jackson.version>2.12.3</jackson.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>

--- a/vertx-mutiny-clients/pom.xml
+++ b/vertx-mutiny-clients/pom.xml
@@ -49,7 +49,7 @@
         <module>vertx-mutiny-jdbc-client</module>
         <module>vertx-mutiny-json-schema</module>
         <module>vertx-mutiny-web-validation</module>
-        <module>vertx-mutiny-web-openapi</module>
+<!--        <module>vertx-mutiny-web-openapi</module>-->
         <module>vertx-mutiny-web-templ-freemarker</module>
         <module>vertx-mutiny-web-templ-handlebars</module>
         <module>vertx-mutiny-web-templ-jade</module>

--- a/vertx-mutiny-clients/vertx-mutiny-auth-sql-client/src/test/java/io/smallrye/mutiny/vertx/auth/AuthSqlClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-auth-sql-client/src/test/java/io/smallrye/mutiny/vertx/auth/AuthSqlClientTest.java
@@ -24,7 +24,7 @@ import io.vertx.sqlclient.PoolOptions;
 public class AuthSqlClientTest {
 
     @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>("mysql:5.7")
+    public static GenericContainer<?> container = new GenericContainer<>("mysql:8")
             .withEnv("MYSQL_USER", "mysql")
             .withEnv("MYSQL_PASSWORD", "password")
             .withEnv("MYSQL_ROOT_PASSWORD", "password")

--- a/vertx-mutiny-clients/vertx-mutiny-cassandra-client/src/test/java/io/vertx/mutiny/cassandra/CassandraClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-cassandra-client/src/test/java/io/vertx/mutiny/cassandra/CassandraClientTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.CassandraContainer;
-import org.testcontainers.containers.GenericContainer;
 
 import io.vertx.cassandra.CassandraClientOptions;
 import io.vertx.mutiny.core.Vertx;
@@ -15,7 +14,7 @@ import io.vertx.mutiny.core.Vertx;
 public class CassandraClientTest {
 
     @Rule
-    public GenericContainer<?> container = new CassandraContainer<>()
+    public CassandraContainer<?> container = new CassandraContainer<>("cassandra:3.11")
             .withExposedPorts(9042);
 
     private Vertx vertx;

--- a/vertx-mutiny-clients/vertx-mutiny-consul-client/src/test/java/io/vertx/mutiny/consul/ConsulClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-consul-client/src/test/java/io/vertx/mutiny/consul/ConsulClientTest.java
@@ -18,7 +18,7 @@ import io.vertx.mutiny.ext.consul.ConsulClient;
 public class ConsulClientTest {
 
     @Rule
-    public GenericContainer<?> container = new GenericContainer<>("consul:latest")
+    public GenericContainer<?> container = new GenericContainer<>("consul:1.9")
             .withExposedPorts(8500);
 
     private Vertx vertx;

--- a/vertx-mutiny-clients/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/MutinyGenerator.java
+++ b/vertx-mutiny-clients/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/MutinyGenerator.java
@@ -200,7 +200,7 @@ public class MutinyGenerator extends Generator<ClassModel> {
             ListIterator<MethodInfo> it = methods.listIterator();
             while (it.hasNext()) {
                 MethodInfo method = it.next();
-                if (CodeGenHelper.methodKind(method) != MethodKind.FUTURE) {
+                if (CodeGenHelper.methodKind(method) != MethodKind.CALLBACK) {
                     // Has it been removed above ?
                     Predicate<MethodInfo> pred;
                     if (method.isOwnedBy(model.getType())) {
@@ -209,7 +209,7 @@ public class MutinyGenerator extends Generator<ClassModel> {
                         pred = other -> isOverride(method, other);
                     }
                     if (methods.stream()
-                            .filter(m -> CodeGenHelper.methodKind(m) == MethodKind.FUTURE)
+                            .filter(m -> CodeGenHelper.methodKind(m) == MethodKind.CALLBACK)
                             .anyMatch(pred)) {
                         it.remove();
                     }
@@ -220,18 +220,18 @@ public class MutinyGenerator extends Generator<ClassModel> {
             it = methods.listIterator();
             while (it.hasNext()) {
                 MethodInfo meth = it.next();
-                if (CodeGenHelper.methodKind(meth) == MethodKind.FUTURE) {
+                if (CodeGenHelper.methodKind(meth) == MethodKind.CALLBACK) {
                     boolean remove;
                     List<MethodInfo> abc = model.getMethodMap().getOrDefault(meth.getName(), Collections.emptyList());
                     if (meth.isOwnedBy(model.getType())) {
                         remove = abc.stream()
-                                .filter(m -> CodeGenHelper.methodKind(m) != MethodKind.FUTURE && isOverride(m, meth))
+                                .filter(m -> CodeGenHelper.methodKind(m) != MethodKind.CALLBACK && isOverride(m, meth))
                                 .anyMatch(m -> !m.isOwnedBy(model.getType()) || methods.contains(m));
                     } else {
                         remove = abc.stream()
-                                .filter(other -> CodeGenHelper.methodKind(other) != MethodKind.FUTURE)
+                                .filter(other -> CodeGenHelper.methodKind(other) != MethodKind.CALLBACK)
                                 .anyMatch(other -> {
-                                    if (CodeGenHelper.methodKind(other) != MethodKind.FUTURE) {
+                                    if (CodeGenHelper.methodKind(other) != MethodKind.CALLBACK) {
                                         Set<ClassTypeInfo> tmp = new HashSet<>(other.getOwnerTypes());
                                         tmp.retainAll(meth.getOwnerTypes());
                                         return isOverride(meth, other) & !tmp.isEmpty();
@@ -308,7 +308,7 @@ public class MutinyGenerator extends Generator<ClassModel> {
         AwaitMethodGenerator await = new AwaitMethodGenerator(writer);
         ConsumerMethodGenerator consumer = new ConsumerMethodGenerator(writer);
         SimpleMethodGenerator simple = new SimpleMethodGenerator(writer, cacheDecls, methodTypeArgMap);
-        if (CodeGenHelper.methodKind(method) == MethodKind.FUTURE) {
+        if (CodeGenHelper.methodKind(method) == MethodKind.CALLBACK) {
             uni.generate(model, method);
             await.generate(method);
             forget.generate(model, method);
@@ -337,7 +337,7 @@ public class MutinyGenerator extends Generator<ClassModel> {
 
     private void generateMethodDeclaration(ClassModel model, MethodInfo method, List<String> cacheDecls,
             PrintWriter writer) {
-        if (CodeGenHelper.methodKind(method) == MethodKind.FUTURE) {
+        if (CodeGenHelper.methodKind(method) == MethodKind.CALLBACK) {
             new UniMethodGenerator(writer, methodTypeArgMap).generateDeclaration(method);
             if (model.getMethods().stream()
                     .noneMatch(mi -> mi.getName().equals(method.getName() + AwaitMethodGenerator.SUFFIX_AND_AWAIT))) {

--- a/vertx-mutiny-clients/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/lang/CodeGenHelper.java
+++ b/vertx-mutiny-clients/vertx-mutiny-generator/src/main/java/io/smallrye/mutiny/vertx/codegen/lang/CodeGenHelper.java
@@ -48,7 +48,7 @@ public class CodeGenHelper {
             if (lastParamType.getKind() == ClassKind.HANDLER) {
                 TypeInfo typeArg = ((ParameterizedTypeInfo) lastParamType).getArgs().get(0);
                 if (typeArg.getKind() == ClassKind.ASYNC_RESULT) {
-                    return MethodKind.FUTURE;
+                    return MethodKind.CALLBACK;
                 } else {
                     return MethodKind.HANDLER;
                 }
@@ -230,6 +230,9 @@ public class CodeGenHelper {
                 return expr + ".entrySet().stream().collect(java.util.stream.Collectors.toMap(e -> e.getKey(), e -> "
                         + genConvParam(methodTypeArgMap, parameterizedTypeInfo.getArg(1), method, "e.getValue()")
                         + "))";
+            } else if (kind == FUTURE) {
+                ParameterizedTypeInfo futureType = (ParameterizedTypeInfo) type;
+                return expr + ".map(val -> " + genConvParam(methodTypeArgMap, futureType.getArg(0), method, "val") + ")";
             }
         }
         return expr;
@@ -242,7 +245,7 @@ public class CodeGenHelper {
         // If the retType if a Future<X> and X is of type API, we need to unwrap the mutiny type to the bare type
         // (call getDelegate())
         boolean appendDelegate = false;
-        if (retType.isParameterized()  && retType.getKind() == FUTURE) {
+        if (retType.getKind() == FUTURE) {
             ParameterizedTypeInfo ret = (ParameterizedTypeInfo) retType;
             appendDelegate = ret.getArg(0).getKind() == API;
         }
@@ -402,6 +405,9 @@ public class CodeGenHelper {
             } else if (kind == MAP) {
                 return expr + ".entrySet().stream().collect(Collectors.toMap(_e -> _e.getKey(), _e -> " + genConvReturn(
                         methodTypeArgMap, parameterizedTypeInfo.getArg(1), method, "_e.getValue()") + "))";
+            } else if (kind == FUTURE) {
+                ParameterizedTypeInfo futureType = (ParameterizedTypeInfo) type;
+                return expr + ".map(val -> " + genConvReturn(methodTypeArgMap, futureType.getArg(0), method, "val") + ")";
             }
         }
         return expr;

--- a/vertx-mutiny-clients/vertx-mutiny-mongo-client/src/test/java/io/vertx/mutiny/mongo/MongoClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-mongo-client/src/test/java/io/vertx/mutiny/mongo/MongoClientTest.java
@@ -17,7 +17,7 @@ import io.vertx.mutiny.ext.mongo.MongoClient;
 public class MongoClientTest {
 
     @Rule
-    public GenericContainer<?> container = new GenericContainer<>("mongo:latest")
+    public GenericContainer<?> container = new GenericContainer<>("mongo:4.4")
             .withExposedPorts(27017);
 
     private Vertx vertx;

--- a/vertx-mutiny-clients/vertx-mutiny-mqtt/src/test/java/io/vertx/mutiny/mqtt/MqttClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-mqtt/src/test/java/io/vertx/mutiny/mqtt/MqttClientTest.java
@@ -20,7 +20,7 @@ import io.vertx.mutiny.mqtt.messages.MqttConnAckMessage;
 public class MqttClientTest {
 
     @ClassRule
-    public static GenericContainer<?> mosquitto = new GenericContainer<>("eclipse-mosquitto:latest")
+    public static GenericContainer<?> mosquitto = new GenericContainer<>("eclipse-mosquitto:2.0")
             .withExposedPorts(1883)
             .withClasspathResourceMapping("mosquitto.conf", "/mosquitto/config/mosquitto.conf", BindMode.READ_ONLY)
             .waitingFor(Wait.forLogMessage(".*mosquitto .* running.*", 1));

--- a/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySQLClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySQLClientTest.java
@@ -17,7 +17,7 @@ public class MySQLClientTest {
     private static final String MYSQL_DATABASE = "test";
 
     @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>("mysql:latest")
+    public static GenericContainer<?> container = new GenericContainer<>("mysql:8")
             .withExposedPorts(3306)
             .withEnv("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
             .withEnv("MYSQL_DATABASE", MYSQL_DATABASE);

--- a/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlInTransactionMultiTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlInTransactionMultiTest.java
@@ -18,7 +18,7 @@ public class MySqlInTransactionMultiTest extends TransactionMultiTest {
     private static final String MYSQL_DATABASE = "test";
 
     @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>("mysql:latest")
+    public static GenericContainer<?> container = new GenericContainer<>("mysql:8")
             .withExposedPorts(3306)
             .withEnv("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
             .withEnv("MYSQL_DATABASE", MYSQL_DATABASE);

--- a/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlInTransactionUniTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlInTransactionUniTest.java
@@ -18,7 +18,7 @@ public class MySqlInTransactionUniTest extends TransactionUniTest {
     private static final String MYSQL_DATABASE = "test";
 
     @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>("mysql:latest")
+    public static GenericContainer<?> container = new GenericContainer<>("mysql:8")
             .withExposedPorts(3306)
             .withEnv("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
             .withEnv("MYSQL_DATABASE", MYSQL_DATABASE);

--- a/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlUsingConnectionSafetyTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-mysql-client/src/test/java/io/vertx/mutiny/mysql/MySqlUsingConnectionSafetyTest.java
@@ -16,7 +16,7 @@ public class MySqlUsingConnectionSafetyTest extends UsingConnectionSafetyTest {
     private static final String MYSQL_DATABASE = "test";
 
     @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>("mysql:latest")
+    public static GenericContainer<?> container = new GenericContainer<>("mysql:8")
             .withExposedPorts(3306)
             .withEnv("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
             .withEnv("MYSQL_DATABASE", MYSQL_DATABASE);

--- a/vertx-mutiny-clients/vertx-mutiny-rabbitmq-client/src/test/java/io/vertx/mutiny/rabbitmq/RabbitMQClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-rabbitmq-client/src/test/java/io/vertx/mutiny/rabbitmq/RabbitMQClientTest.java
@@ -29,7 +29,7 @@ public class RabbitMQClientTest {
 
     private static final String QUEUE = "my-queue";
     @Rule
-    public GenericContainer<?> container = new FixedHostPortGenericContainer<>("rabbitmq:alpine")
+    public GenericContainer<?> container = new FixedHostPortGenericContainer<>("rabbitmq:3.8-alpine")
             .withCreateContainerCmdModifier(cmd -> cmd.withHostName("my-rabbit"))
             .withExposedPorts(5672);
 

--- a/vertx-mutiny-clients/vertx-mutiny-redis-client/src/test/java/io/vertx/mutiny/redis/RedisClientTest.java
+++ b/vertx-mutiny-clients/vertx-mutiny-redis-client/src/test/java/io/vertx/mutiny/redis/RedisClientTest.java
@@ -20,7 +20,7 @@ import io.vertx.redis.client.RedisOptions;
 public class RedisClientTest {
 
     @Rule
-    public GenericContainer<?> container = new GenericContainer<>("redis:latest")
+    public GenericContainer<?> container = new GenericContainer<>("redis:6.2")
             .withExposedPorts(6379);
 
     private Vertx vertx;


### PR DESCRIPTION
Update to Vert.x 4.1.0.CR2

* fix code generator when a function does not expect the result to be a translated type
* disable vertx-mutiny-web-openapi - need to be investigated